### PR TITLE
feat: Add bash aliases for claude-flow commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,35 @@ npx flow-tools load-preferences
 npx flow-tools sync
 ```
 
+### Bash Aliases
+
+Quick shortcuts for common claude-flow commands:
+
+```bash
+# Install the aliases
+cd bash-aliases
+./install.sh
+
+# Available aliases:
+cf                              # npx claude-flow@alpha
+cfs                             # npx claude-flow@alpha swarm
+cfh                             # npx claude-flow@alpha hive-mind spawn
+cfa                             # npx claude-flow@alpha agent
+cft                             # npx claude-flow@alpha task
+cfm                             # npx claude-flow@alpha memory
+cfc                             # npx claude-flow@alpha config
+cfi                             # npx claude-flow@alpha init
+cfst                            # npx claude-flow@alpha status
+cfp                             # npx claude-flow@alpha plan
+
+# Convenience functions (auto-add --claude flag):
+cfswarm "Build a REST API"      # npx claude-flow@alpha swarm "..." --claude
+cfhive "Optimize database"      # npx claude-flow@alpha hive-mind spawn "..." --claude
+cfhelp                          # Show all available aliases
+```
+
+See [bash-aliases/README.md](bash-aliases/README.md) for detailed documentation.
+
 ## Directory Structure
 
 ```
@@ -71,6 +100,7 @@ flow-tools/
 ├── preferences/        # User preferences and configurations
 ├── templates/          # Project templates
 ├── scripts/            # CLI scripts
+├── bash-aliases/       # Convenient shell aliases for claude-flow
 └── docs/              # Documentation
 ```
 

--- a/bash-aliases/README.md
+++ b/bash-aliases/README.md
@@ -1,0 +1,116 @@
+# Claude Flow Bash Aliases
+
+Quick and convenient bash/zsh aliases for common `claude-flow` commands.
+
+## Installation
+
+```bash
+# Make the install script executable
+chmod +x install.sh
+
+# Run the installer
+./install.sh
+```
+
+The installer will:
+1. Detect your shell configuration file (`.bashrc`, `.zshrc`, etc.)
+2. Add the aliases to your shell configuration
+3. Create a backup of your configuration file
+
+## Usage
+
+After installation, you can use these shortcuts:
+
+### Basic Aliases
+
+| Alias | Command | Description |
+|-------|---------|-------------|
+| `cf` | `npx claude-flow@alpha` | Basic claude-flow command |
+| `cfs` | `npx claude-flow@alpha swarm` | Swarm command |
+| `cfh` | `npx claude-flow@alpha hive-mind spawn` | Hive-mind spawn command |
+| `cfa` | `npx claude-flow@alpha agent` | Agent management |
+| `cft` | `npx claude-flow@alpha task` | Task management |
+| `cfm` | `npx claude-flow@alpha memory` | Memory operations |
+| `cfc` | `npx claude-flow@alpha config` | Configuration |
+| `cfi` | `npx claude-flow@alpha init` | Initialize project |
+| `cfst` | `npx claude-flow@alpha status` | Check status |
+| `cfp` | `npx claude-flow@alpha plan` | Planning mode |
+
+### Functions
+
+#### `cfswarm`
+Run a swarm with an objective (automatically adds `--claude` flag):
+```bash
+cfswarm "Build a REST API with authentication"
+```
+
+#### `cfhive`
+Run hive-mind spawn with an objective (automatically adds `--claude` flag):
+```bash
+cfhive "Analyze and optimize database queries"
+```
+
+#### `cfhelp`
+Display help for all available aliases:
+```bash
+cfhelp
+```
+
+## Examples
+
+```bash
+# Basic usage
+cf --help                              # Show claude-flow help
+cfs --list                             # List available swarms
+
+# Using the convenience functions
+cfswarm "Create a user authentication system with JWT tokens"
+cfhive "Refactor the codebase to improve performance"
+
+# Quick commands
+cfa list                               # List agents
+cft status                             # Check task status
+cfm store key value                    # Store in memory
+```
+
+## Uninstallation
+
+To remove the aliases:
+
+```bash
+# Make the uninstall script executable
+chmod +x uninstall.sh
+
+# Run the uninstaller
+./uninstall.sh
+```
+
+## Customization
+
+You can edit `claude-flow-aliases.sh` to add your own custom aliases or modify existing ones. After making changes, reload your shell configuration:
+
+```bash
+source ~/.bashrc  # or ~/.zshrc for zsh users
+```
+
+## Troubleshooting
+
+### Aliases not working
+1. Make sure you've restarted your terminal or run `source ~/.bashrc` (or `~/.zshrc`)
+2. Check that the aliases file path in your shell config is correct
+3. Verify that `claude-flow-aliases.sh` exists and is readable
+
+### Permission denied
+Make sure the scripts are executable:
+```bash
+chmod +x install.sh uninstall.sh
+```
+
+### Wrong shell detected
+You can manually add the following to your shell configuration file:
+```bash
+# Claude Flow Aliases
+if [ -f "/path/to/flow-tools/bash-aliases/claude-flow-aliases.sh" ]; then
+    source "/path/to/flow-tools/bash-aliases/claude-flow-aliases.sh"
+fi
+```

--- a/bash-aliases/claude-flow-aliases.sh
+++ b/bash-aliases/claude-flow-aliases.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Claude Flow Bash Aliases
+# Quick shortcuts for common claude-flow commands
+
+# Basic claude-flow command
+alias cf='npx claude-flow@alpha'
+
+# Swarm command with claude integration
+alias cfs='npx claude-flow@alpha swarm'
+
+# Hive-mind spawn command with claude integration
+alias cfh='npx claude-flow@alpha hive-mind spawn'
+
+# Additional useful aliases
+alias cfa='npx claude-flow@alpha agent'          # Agent management
+alias cft='npx claude-flow@alpha task'           # Task management
+alias cfm='npx claude-flow@alpha memory'         # Memory operations
+alias cfc='npx claude-flow@alpha config'         # Configuration
+alias cfi='npx claude-flow@alpha init'           # Initialize project
+alias cfst='npx claude-flow@alpha status'        # Check status
+alias cfp='npx claude-flow@alpha plan'           # Planning mode
+
+# Function for swarm with objective (includes --claude flag automatically)
+cfswarm() {
+    if [ -z "$1" ]; then
+        echo "Usage: cfswarm 'Your objective here'"
+        echo "Example: cfswarm 'Build a REST API with authentication'"
+        return 1
+    fi
+    npx claude-flow@alpha swarm "$1" --claude
+}
+
+# Function for hive-mind spawn with objective (includes --claude flag automatically)
+cfhive() {
+    if [ -z "$1" ]; then
+        echo "Usage: cfhive 'Your objective here'"
+        echo "Example: cfhive 'Analyze and optimize database queries'"
+        return 1
+    fi
+    npx claude-flow@alpha hive-mind spawn "$1" --claude
+}
+
+# Quick help function
+cfhelp() {
+    echo "Claude Flow Aliases:"
+    echo "  cf       - Basic claude-flow command"
+    echo "  cfs      - Swarm command"
+    echo "  cfh      - Hive-mind spawn command"
+    echo "  cfa      - Agent management"
+    echo "  cft      - Task management"
+    echo "  cfm      - Memory operations"
+    echo "  cfc      - Configuration"
+    echo "  cfi      - Initialize project"
+    echo "  cfst     - Check status"
+    echo "  cfp      - Planning mode"
+    echo ""
+    echo "Functions:"
+    echo "  cfswarm 'objective' - Run swarm with objective (auto-adds --claude)"
+    echo "  cfhive 'objective'  - Run hive-mind with objective (auto-adds --claude)"
+    echo "  cfhelp             - Show this help message"
+}

--- a/bash-aliases/install.sh
+++ b/bash-aliases/install.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Claude Flow Aliases Installation Script
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Claude Flow Aliases Installer${NC}"
+echo "=============================="
+
+# Detect shell configuration file
+detect_shell_config() {
+    if [ -n "$BASH_VERSION" ]; then
+        if [ -f "$HOME/.bashrc" ]; then
+            echo "$HOME/.bashrc"
+        elif [ -f "$HOME/.bash_profile" ]; then
+            echo "$HOME/.bash_profile"
+        else
+            echo "$HOME/.bashrc"
+        fi
+    elif [ -n "$ZSH_VERSION" ]; then
+        if [ -f "$HOME/.zshrc" ]; then
+            echo "$HOME/.zshrc"
+        else
+            echo "$HOME/.zshrc"
+        fi
+    else
+        echo "$HOME/.bashrc"
+    fi
+}
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ALIASES_FILE="$SCRIPT_DIR/claude-flow-aliases.sh"
+
+# Check if aliases file exists
+if [ ! -f "$ALIASES_FILE" ]; then
+    echo -e "${RED}Error: claude-flow-aliases.sh not found in $SCRIPT_DIR${NC}"
+    exit 1
+fi
+
+# Detect shell config file
+SHELL_CONFIG=$(detect_shell_config)
+echo -e "Detected shell configuration file: ${YELLOW}$SHELL_CONFIG${NC}"
+
+# Check if aliases are already installed
+if grep -q "claude-flow-aliases.sh" "$SHELL_CONFIG" 2>/dev/null; then
+    echo -e "${YELLOW}Claude Flow aliases appear to be already installed.${NC}"
+    read -p "Do you want to reinstall? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Installation cancelled."
+        exit 0
+    fi
+    # Remove existing installation
+    sed -i.bak '/# Claude Flow Aliases/,/claude-flow-aliases\.sh"/d' "$SHELL_CONFIG"
+    echo "Removed existing installation."
+fi
+
+# Create backup of shell config
+cp "$SHELL_CONFIG" "${SHELL_CONFIG}.backup.$(date +%Y%m%d_%H%M%S)"
+echo "Created backup of $SHELL_CONFIG"
+
+# Add source command to shell config
+echo "" >> "$SHELL_CONFIG"
+echo "# Claude Flow Aliases" >> "$SHELL_CONFIG"
+echo "if [ -f \"$ALIASES_FILE\" ]; then" >> "$SHELL_CONFIG"
+echo "    source \"$ALIASES_FILE\"" >> "$SHELL_CONFIG"
+echo "fi" >> "$SHELL_CONFIG"
+
+echo -e "${GREEN}✓ Aliases installed successfully!${NC}"
+echo ""
+echo "To start using the aliases, either:"
+echo "  1. Restart your terminal, or"
+echo "  2. Run: source $SHELL_CONFIG"
+echo ""
+echo "Type 'cfhelp' to see available aliases and commands."
+echo ""
+echo "Example usage:"
+echo "  cf                           # Run claude-flow"
+echo "  cfswarm 'Build a REST API'   # Start a swarm with objective"
+echo "  cfhive 'Optimize database'   # Start hive-mind with objective"

--- a/bash-aliases/uninstall.sh
+++ b/bash-aliases/uninstall.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Claude Flow Aliases Uninstallation Script
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Claude Flow Aliases Uninstaller${NC}"
+echo "================================"
+
+# Detect shell configuration file
+detect_shell_config() {
+    if [ -n "$BASH_VERSION" ]; then
+        if [ -f "$HOME/.bashrc" ]; then
+            echo "$HOME/.bashrc"
+        elif [ -f "$HOME/.bash_profile" ]; then
+            echo "$HOME/.bash_profile"
+        else
+            echo "$HOME/.bashrc"
+        fi
+    elif [ -n "$ZSH_VERSION" ]; then
+        if [ -f "$HOME/.zshrc" ]; then
+            echo "$HOME/.zshrc"
+        else
+            echo "$HOME/.zshrc"
+        fi
+    else
+        echo "$HOME/.bashrc"
+    fi
+}
+
+# Detect shell config file
+SHELL_CONFIG=$(detect_shell_config)
+echo -e "Detected shell configuration file: ${YELLOW}$SHELL_CONFIG${NC}"
+
+# Check if aliases are installed
+if ! grep -q "claude-flow-aliases.sh" "$SHELL_CONFIG" 2>/dev/null; then
+    echo -e "${YELLOW}Claude Flow aliases are not installed in $SHELL_CONFIG${NC}"
+    exit 0
+fi
+
+# Confirm uninstallation
+read -p "Are you sure you want to uninstall Claude Flow aliases? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Uninstallation cancelled."
+    exit 0
+fi
+
+# Create backup before removing
+cp "$SHELL_CONFIG" "${SHELL_CONFIG}.backup.$(date +%Y%m%d_%H%M%S)"
+echo "Created backup of $SHELL_CONFIG"
+
+# Remove aliases from shell config
+sed -i.bak '/# Claude Flow Aliases/,/claude-flow-aliases\.sh"/d' "$SHELL_CONFIG"
+
+# Clean up empty lines if any
+sed -i '/^$/N;/^\n$/d' "$SHELL_CONFIG"
+
+echo -e "${GREEN}✓ Claude Flow aliases uninstalled successfully!${NC}"
+echo ""
+echo "The aliases will no longer be available in new terminal sessions."
+echo "To remove them from the current session, restart your terminal."


### PR DESCRIPTION
## Summary
- Implemented comprehensive bash/zsh aliases for common claude-flow commands as requested in issue #1
- Created easy-to-use installation and uninstallation scripts
- Added convenience functions that automatically include the `--claude` flag

## Changes
- Created `bash-aliases/` directory with:
  - `claude-flow-aliases.sh` - Main aliases file with all shortcuts
  - `install.sh` - Automated installer that detects shell type
  - `uninstall.sh` - Clean removal script
  - `README.md` - Detailed documentation
- Updated main README.md with usage instructions

## Features
### Basic Aliases
- `cf` → `npx claude-flow@alpha`
- `cfs` → `npx claude-flow@alpha swarm`
- `cfh` → `npx claude-flow@alpha hive-mind spawn`
- Additional shortcuts for agent, task, memory, config, init, status, and plan commands

### Convenience Functions
- `cfswarm "objective"` - Runs swarm with auto `--claude` flag
- `cfhive "objective"` - Runs hive-mind spawn with auto `--claude` flag
- `cfhelp` - Displays all available aliases

## Installation
```bash
cd bash-aliases
./install.sh
```

The installer:
- Automatically detects bash/zsh
- Creates backup of shell config
- Adds source command to load aliases
- Provides clear instructions

## Test Plan
- [x] Tested alias functionality in bash environment
- [x] Verified help command displays correctly
- [x] Installation script creates proper backups
- [ ] Test on zsh shell
- [ ] Test on macOS environment

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)